### PR TITLE
remove pitest configuration from pom.xml

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -48,6 +48,7 @@
 	        <groupId>org.mockito</groupId>
 	        <artifactId>mockito-junit-jupiter</artifactId>
 	        <version>5.6.0</version>
+            <scope>test</scope>
 	    </dependency>
 
         <!-- Uncomment to use Eclipse Paho Mqttv5 Client -->
@@ -74,6 +75,7 @@
                 <artifactId>maven-surefire-plugin</artifactId>
                 <version>3.2.1</version>
             </plugin>
+
             <plugin>
 				<groupId>org.jacoco</groupId>
 				<artifactId>jacoco-maven-plugin</artifactId>
@@ -97,32 +99,6 @@
 							<goal>report</goal>
 						</goals>
 					</execution>				
-				</executions>
-			</plugin>
-			<plugin>
-				<groupId>org.pitest</groupId>
-				<artifactId>pitest-maven</artifactId>
-				<version>1.15.1</version>
-				<configuration>
-					<excludedClasses>
-						<param>**.*ElevatorExample</param>
-					</excludedClasses>
-				</configuration>
-				<dependencies>
-					<dependency>
-						<groupId>org.pitest</groupId>
-						<artifactId>pitest-junit5-plugin</artifactId>
-						<version>1.2.0</version>
-					</dependency>
-				</dependencies>
-				<executions>
-					<execution>
-						<id>pitest-mutation-coverage</id>
-						<phase>test</phase>
-						<goals>
-							<goal>mutationCoverage</goal>
-						</goals>					
-					</execution>
 				</executions>
 			</plugin>
         </plugins>


### PR DESCRIPTION
Remove pitest config from pom.xml as it conflicts with jacoco coverage reporting.
When this problem has been solved, we can enable pitest again in a future PR.